### PR TITLE
Add version endpoint to API

### DIFF
--- a/src/medaitor/api/routes.py
+++ b/src/medaitor/api/routes.py
@@ -49,6 +49,17 @@ async def get_room(room_id: str):
     )
 
 
+@router.get("/version")
+async def get_version():
+    """Get application version information."""
+    from medaitor import __version__
+    return {
+        "version": __version__,
+        "app": "Mediator",
+        "description": "AI-assisted conversation moderator"
+    }
+
+
 @router.get("/rules")
 async def get_rules():
     """Get community rules."""


### PR DESCRIPTION
## Summary
Add a new `/api/version` endpoint that returns application version information.

## Changes
- Added `GET /api/version` endpoint to return version, app name, and description
- Imports version from the main package module

## Test Plan
- [x] Endpoint returns JSON with version information
- [x] Response includes app name and description
- [ ] Manual testing via curl or browser

## Example Response
```json
{
  "version": "0.1.0",
  "app": "Mediator", 
  "description": "AI-assisted conversation moderator"
}
```

🤖 Generated with [Claude Code](https://claude.ai/code)